### PR TITLE
bugfix/template-attribute-update-not-working-with-objects

### DIFF
--- a/actions/template_attributes_update.py
+++ b/actions/template_attributes_update.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dict2xml import dict2xml
 from lib.action_base import BaseAction
 
 
@@ -24,5 +25,6 @@ class TemplateAttributeUpdate(BaseAction):
         :returns: Return object with the template ID
         """
         one = self.pyone_session_create(open_nebula)
+        xml = dict2xml({'TEMPLATE': attributes})
         # The 1 below merges this new template with the existing one
-        return one.template.update(template_id, attributes, 1)
+        return one.template.update(template_id, xml, 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 pyone
 pybase64
 xmltojson
+dict2xml

--- a/tests/test_action_template_attributes_update.py
+++ b/tests/test_action_template_attributes_update.py
@@ -26,23 +26,27 @@ class TemplateAttributeUpdateTestCase(OneBaseActionTestCase):
     __test__ = True
     action_cls = TemplateAttributeUpdate
 
+    @mock.patch("template_attributes_update.dict2xml")
     @mock.patch("lib.action_base.BaseAction.pyone_session_create")
-    def test_run(self, mock_session):
+    def test_run(self, mock_session, mock_dict2xml):
         action = self.get_action_instance(self._config_good)
 
         # Define test parameters
         attributes = {'ATTR': 'VALUE'}
         template_id = 0
         open_nebula = 'default'
+        test_xml = 'xml string'
         expected_result = 'result'
 
         # Mock one object and run action
         mock_one = mock.Mock()
         mock_one.template.update.return_value = expected_result
+        mock_dict2xml.return_value = test_xml
         mock_session.return_value = mock_one
         result = action.run(attributes, template_id, open_nebula)
 
         # Verify result and calls
         self.assertEqual(expected_result, result)
         mock_session.assert_called_with(open_nebula)
-        mock_one.template.update.assert_called_with(template_id, attributes, 1)
+        mock_dict2xml.assert_called_with({'TEMPLATE': attributes})
+        mock_one.template.update.assert_called_with(template_id, test_xml, 1)


### PR DESCRIPTION
Converted template attributes object to XML because objects were getting added to attributes as strings