### PR TITLE
hotfix/pin-pyone

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-pyone
+pyone==6.10.0
 pybase64
 xmltojson
 dict2xml


### PR DESCRIPTION
Pins pyone module to fix errors with enum.

The newest version of pyone (6.10.1) swapped dependencies from aenum to enum which causes problems with versions of python greater than 3.4 when enum was introduced as a standard module.